### PR TITLE
[WIP] Store open timeslots in a separate table

### DIFF
--- a/flocx_market/db/sqlalchemy/api.py
+++ b/flocx_market/db/sqlalchemy/api.py
@@ -44,6 +44,11 @@ def offer_get(marketplace_offer_id, context):
             marketplace_offer_id=marketplace_offer_id).one_or_none()
 
 
+def offer_get_by_provider_offer_id(provider_offer_id, context):
+    return get_session().query(models.Offer).filter_by(
+            provider_offer_id=provider_offer_id).one_or_none()
+
+
 def offer_get_all(context):
     return get_session().query(models.Offer).all()
 
@@ -68,6 +73,13 @@ def offer_create(values, context):
     values['marketplace_offer_id'] = uuidutils.generate_uuid()
     offer_ref = models.Offer()
     offer_ref.update(values)
+
+    if 'timeslots' not in values:
+        offer_ref.timeslots.append(models.Timeslot(
+            offer_id=offer_ref.marketplace_offer_id,
+            start_time=offer_ref.start_time,
+            end_time=offer_ref.end_time,
+        ))
     offer_ref.save(get_session())
     return offer_ref
 

--- a/flocx_market/db/sqlalchemy/models.py
+++ b/flocx_market/db/sqlalchemy/models.py
@@ -60,6 +60,7 @@ class Offer(Base):
     server_id = orm.Column(orm.String(64), nullable=False, unique=True)
     start_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
     end_time = orm.Column(orm.DateTime(timezone=True), nullable=True)
+    timeslots = orm.relationship('Timeslot')
     server_config = orm.Column(
         sqlalchemy_jsonfield.JSONField(enforce_string=True,
                                        enforce_unicode=False),
@@ -68,6 +69,22 @@ class Offer(Base):
     cost = orm.Column(orm.Float, nullable=False)
     offer_contract_relationships = orm.relationship(
         'OfferContractRelationship', lazy='dynamic')
+
+
+class Timeslot(Base):
+    __tablename__ = 'timeslots'
+    timeslot_id = orm.Column(orm.Integer,
+                             primary_key=True)
+    offer_id = orm.Column(orm.String(64), orm.ForeignKey(
+        'offers.marketplace_offer_id', ondelete='CASCADE'))
+    start_time = orm.Column(orm.DateTime(timezone=True), nullable=False)
+    end_time = orm.Column(orm.DateTime(timezone=True), nullable=True)
+
+    orm.UniqueConstraint('offer_id', 'start_time', 'end_time')
+
+    def __repr__(self):
+        return ('<timeslot o {0.offer_id} '
+                's {0.start_time} e {0.end_time}>'.format(self))
 
 
 class Contract(Base):

--- a/flocx_market/objects/offer.py
+++ b/flocx_market/objects/offer.py
@@ -36,6 +36,17 @@ class Offer(base.FLOCXMarketObject):
             else:
                 return cls._from_db_object(cls(), o)
 
+    @classmethod
+    def get_by_provider_offer_id(cls, offer_id, context):
+        if offer_id is None:
+            return None
+        else:
+            o = db.offer_get_by_provider_offer_id(offer_id, context)
+            if o is None:
+                return None
+            else:
+                return cls._from_db_object(cls(), o)
+
     def destroy(self, context):
         db.offer_destroy(self.marketplace_offer_id, context)
         return True

--- a/timeslots_example.py
+++ b/timeslots_example.py
@@ -1,0 +1,60 @@
+import datetime
+
+import flocx_market.db.sqlalchemy.api as db_api
+import flocx_market.db.sqlalchemy.models as models
+from flocx_market.objects.offer import Offer
+from flocx_market.common.service import prepare_service
+from flocx_market.conf import CONF
+from flocx_market.api.app import create_app
+from flocx_market.db.orm import orm
+
+from oslo_db.exception import DBDuplicateEntry
+
+
+CONF.clear()
+prepare_service()
+CONF.set_override("auth_enable", False, group='api')
+CONF.set_override(
+    'connection',
+    'mysql+pymysql://flocx_market:qwerty123@localhost:3306/flocx_market',
+    group='database')
+
+app = create_app('flocx-market')
+orm.init_app(app)
+ctx = app.app_context()
+ctx.push()
+
+db_api.setup_db()
+
+start_time = datetime.datetime.strptime('2019-08-01 UTC',
+                                        '%Y-%m-%d %Z')
+end_time = start_time + datetime.timedelta(days=14)
+
+try:
+    offer = db_api.offer_create(dict(
+        provider_offer_id='1234',
+        project_id='1234',
+        server_id='1234',
+        start_time=start_time,
+        end_time=end_time,
+        timeslots=[
+            models.Timeslot(start_time=start_time, end_time=start_time + datetime.timedelta(days=2)),
+            models.Timeslot(start_time=start_time + datetime.timedelta(days=4), end_time=start_time + datetime.timedelta(days=6)),
+            models.Timeslot(start_time=start_time + datetime.timedelta(days=10), end_time=end_time)
+        ],
+        server_config={'foo': 'bar'},
+        cost=0,
+    ), None)
+except DBDuplicateEntry:
+    offer = db_api.offer_get_by_provider_offer_id('1234', None)
+
+sess = db_api.get_session()
+
+for timerange in [['2019-07-25 00:00:00', '2019-07-31 00:00:00'],
+                  ['2019-08-03 00:00:00', '2019-08-03 00:00:00']]:
+    available_offers = sess.query(models.Offer).join(models.Timeslot).filter(
+        models.Timeslot.start_time <= timerange[0]).filter(
+            models.Timeslot.end_time >= timerange[1]).all()
+
+    print('For timerange from {} to {} there were {} offers'.format(
+        timerange[0], timerange[1], len(available_offers)))


### PR DESCRIPTION
In order to more efficiently find offers with timeslots that overlap
a bid, we maintain a timeslots table in the database. When an offer is
first created, we add a single timelot that matches the start/end time
of the offer. Whena a contract is created, we remove the existing
timeslot and replace it with (at most) two new entries: (1) the
available time *before* the contract starts and (2) the available time
*after* the contract starts.

This should allow us to find open timeslots with a single query on a
join of the offers and timeslots tables.